### PR TITLE
Update to latest Fury and added the Swagger Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ a Swagger 1.2 document, please first use [swagger-converter](https://github.com/
 
 Requires [Node.js](https://nodejs.org/) and a compiler to install.
 
-Note, at the moment the tool supports only Node.js v0.10. It does not work with Node.js (or io.js) higher than v0.10.
-
 ```bash
 npm install -g swagger2blueprint
 ```

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var parser = require('yargs')
   .strict();
 
 fury.use(require('fury-adapter-apib-serializer'));
+fury.use(require('fury-adapter-swagger'));
 
 // Take a loaded Swagger object and converts it to API Blueprint
 function convert(swagger, done) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger2blueprint",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Converts Swagger into API Blueprint",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "fury": "^0.9.0",
+    "fury": "^1.0.0",
     "fury-adapter-apib-serializer": "^0.1.0",
+    "fury-adapter-swagger": "^0.6.0",
     "request": "^2.57.0",
     "yargs": "^3.10.0"
   }


### PR DESCRIPTION
This should, hopefully, eliminate the constraint on the node.js version. Node dev is not my area of expertise so I apologize in advance for any stupidity.