### PR TITLE
upgrading deps to use latest pre-3.0 fury components

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "fury": "^2.1.0",
-    "fury-adapter-apib-serializer": "^0.1.2",
-    "fury-adapter-swagger": "^0.9.4",
-    "request": "^2.74.0",
-    "yargs": "^3.10.0"
+    "fury": "^2.3.0",
+    "fury-adapter-apib-serializer": "<0.3.1",
+    "fury-adapter-swagger": "^0.10.0",
+    "request": "^2.0",
+    "yargs": "^8.0"
   }
 }


### PR DESCRIPTION
There's a bunch of output bugs in the current versions of fury this package is using (for instance various undefined elements appear).  Upgrading to the latest pre-3.0 fury stuff catches a lot of fixes that overall improve the output and functionality here.